### PR TITLE
Поддержка запуска через grunt-parallelize

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -83,6 +83,10 @@ module.exports = function (grunt) {
                     name: 'foo'
                 }
             },
+	    // grunt-parallelize run fest with same config
+            just_src_without_dest: {
+                src: 'test/fixtures/qux/foo.xml'
+            },
             named_function_within_dynamic_expansion: {
                 files: [{
                     expand: true,                         // Enable dynamic expantion.

--- a/tasks/fest.js
+++ b/tasks/fest.js
@@ -40,7 +40,7 @@ module.exports = function (grunt) {
                     relSrc = f.orig.cwd ? relative(f.orig.cwd, src) : src;
                 } else if (f.orig.src.length === 1 && grunt.file.isFile(f.orig.src[0])) {
                     // file to file mapping
-                    dest = f.dest;
+                    dest = f.dest || src;
                     relSrc = src;
                 } else {
                     // files to directory mapping


### PR DESCRIPTION
grunt-parallelize дергает grunt-fest передавая каждый файл в src отдельно, но не указывая dest