### PR TITLE
Таск должен падать, если один из файлов не скомпилировался

### DIFF
--- a/tasks/fest.js
+++ b/tasks/fest.js
@@ -77,6 +77,8 @@ module.exports = function (grunt) {
                     }
                     grunt.file.write(dest, contents);
                     grunt.log.ok();
+                } else {
+                    grunt.fail.fatal('Can\'t compile ' + src);
                 }
             });
         });


### PR DESCRIPTION
Сейчас у нас есть проблема с тем, что если один из fest шаблонов не скомпилировался, то мы узнаем об этом только если свалится зависящий от него таск