### PR TITLE
Grunt 1x support

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,10 @@ In lieu of a formal styleguide, take care to maintain the existing coding style.
 
 ## Release History
 
+* 2016-10-21 _v1.0.0_
+
+    - Bump to Grunt 1.x support
+
 * 2015-07-20 _v0.1.6_
 
     - Drop support for Node.js 0.8;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-fest",
   "description": "Compile Fest templates",
-  "version": "0.1.6",
+  "version": "1.0.0",
   "homepage": "https://github.com/eprev/grunt-fest",
   "author": {
     "name": "Anton Eprev",

--- a/package.json
+++ b/package.json
@@ -1,43 +1,42 @@
 {
-    "name": "grunt-fest",
-    "description": "Compile Fest templates",
-    "version": "0.1.6",
-    "homepage": "https://github.com/eprev/grunt-fest",
-    "author": {
-        "name": "Anton Eprev",
-        "email": "a.eprev@gmail.com"
-    },
-    "repository": {
-        "type": "git",
-        "url": "git://github.com/eprev/grunt-fest.git"
-    },
-    "bugs": {
-        "url": "https://github.com/eprev/grunt-fest/issues"
-    },
-    "licenses": [{
-        "type": "MIT",
-        "url": "https://github.com/eprev/grunt-fest/blob/master/LICENSE.md"
-    }],
-    "main": "Gruntfile.js",
-    "engines": {
-        "node": ">= 0.10.0"
-    },
-    "scripts": {
-        "test": "grunt test"
-    },
-    "dependencies": {
-        "fest": "0.8.2"
-    },
-    "devDependencies": {
-        "grunt-contrib-jshint": "0.7.2",
-        "grunt-contrib-clean": "0.5.0",
-        "grunt-contrib-nodeunit": "0.2.2",
-        "grunt": "0.4.2"
-    },
-    "peerDependencies": {
-        "grunt": "~0.4.0"
-    },
-    "keywords": [
-        "gruntplugin", "fest"
-    ]
+  "name": "grunt-fest",
+  "description": "Compile Fest templates",
+  "version": "0.1.6",
+  "homepage": "https://github.com/eprev/grunt-fest",
+  "author": {
+    "name": "Anton Eprev",
+    "email": "a.eprev@gmail.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/eprev/grunt-fest.git"
+  },
+  "bugs": {
+    "url": "https://github.com/eprev/grunt-fest/issues"
+  },
+  "license": "MIT",
+  "main": "Gruntfile.js",
+  "engines": {
+    "node": ">= 0.10.0"
+  },
+  "scripts": {
+    "test": "grunt test"
+  },
+  "dependencies": {
+    "fest": "0.8.2"
+  },
+  "devDependencies": {
+    "grunt": "^1.0.0",
+    "grunt-contrib-clean": "^1.0.0",
+    "grunt-contrib-jshint": "^1.0.0",
+    "grunt-contrib-nodeunit": "^1.0.0",
+    "lodash": "^4.16.4"
+  },
+  "peerDependencies": {
+    "grunt": ">=0.4.0"
+  },
+  "keywords": [
+    "gruntplugin",
+    "fest"
+  ]
 }

--- a/tasks/fest.js
+++ b/tasks/fest.js
@@ -11,6 +11,7 @@
 module.exports = function (grunt) {
 
     var path = require('path'),
+        lodash = require('lodash'),
         resolve = path.resolve.bind(process.cwd()),
         requireResolve = function (module) {
             var start = module.substr(0, 2);
@@ -27,7 +28,7 @@ module.exports = function (grunt) {
             basename = path.basename,
             join = path.join,
             relative = path.relative,
-            extend = grunt.util._.extend;
+            extend = lodash.extend;
 
         var compile = require(requireResolve(options.require)).compile;
 


### PR DESCRIPTION
- Update dependencies
- Replace `grunt.util._` with `lodash`
